### PR TITLE
Fix "Channel HashMap is null" on wake up

### DIFF
--- a/app/src/main/java/com/felkertech/cumulustv/model/ChannelDatabase.java
+++ b/app/src/main/java/com/felkertech/cumulustv/model/ChannelDatabase.java
@@ -55,6 +55,7 @@ public class ChannelDatabase {
     protected List<JsonChannel> mJsonChannelsList;
 
     private static ChannelDatabase mChannelDatabase;
+    private static Thread mWorker;
 
     public static ChannelDatabase getInstance(Context context) {
         if (mChannelDatabase == null) {
@@ -382,6 +383,11 @@ public class ChannelDatabase {
     }
 
     public HashMap<String, Long> getHashMap() {
+        try {
+            mWorker.join(5000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
         return mDatabaseHashMap;
     }
 
@@ -439,7 +445,7 @@ public class ChannelDatabase {
      * @param context The application's context for the {@link ContentResolver}.
      */
     protected void initializeHashMap(final Context context) {
-        new Thread(new Runnable() {
+        mWorker = new Thread(new Runnable() {
             @Override
             public void run() {
                 ContentResolver contentResolver = context.getContentResolver();
@@ -470,7 +476,8 @@ public class ChannelDatabase {
                     cursor.close();
                 }
             }
-        }).start();
+        });
+        mWorker.start();
     }
 
     public void eraseData() {


### PR DESCRIPTION
If you turn "off" a Sony Bravia TV while watching a Live Channel
provided by Cumulus TV, wait a while and turn it back on, an error
prompt about "Channel HashMap is null" will appear and the channel will
fail to display.

That is caused by a race condition in the channel database where an
external caller will initialize a hashmap asynchronously via
getInstance() and then immediately use it, typically before the hashmap
has initialized. This race might not cause a problem with only one or
two channels, but if you have a dozen, then it becomes a problem.

This had been driving my mother crazy, so I took a few minutes to track
down the bug, fix it, recompile and install the recompiled version. THe
recompiled version has run without a single "Channel HashMap is null"
error for a week, so I believe that it is okay.

Sadly, the recompiled version breaks Google Drive integration, but I
imagine that is because I do not know how to build it properly such that
it will accept a app/google-services.json rather than any real
regression.

Lastly, the project's license is unclear. I had been very hesitant to
upstream a fix to a project without clarification on the license used by
the project. After some soul searching, I have decided to publish this
patch under the terms of either the Apache 2.0 or MIT licenses. If the
project lead wishes to fix the unclear licensing with a different OSS
license, I would likely be happy to follow suit. However, this fix
itself is so small that I doubt it qualifies for copyright protection,
so the license under which I choose to release it is likely a moot point
unless I start sending more patches.

Signed-off-by: Richard Yao <ryao@gentoo.org>