### PR TITLE
Switch useragent to iOS for compatibility

### DIFF
--- a/app/src/main/java/com/felkertech/cumulustv/player/CumulusWebPlayer.java
+++ b/app/src/main/java/com/felkertech/cumulustv/player/CumulusWebPlayer.java
@@ -19,7 +19,7 @@ public class CumulusWebPlayer extends WebView {
         super.getSettings().setSupportZoom(false);
         super.getSettings().setSupportMultipleWindows(false);
         super.setWebViewClient(new BridgeClient());
-        super.getSettings().setUserAgentString("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.35 Safari/537.36"); //Claim to be a desktop
+        super.getSettings().setUserAgentString("Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1"); // Claim to be iPhone
         super.setKeepScreenOn(true);
         this.mListener = listener;
     }

--- a/app/src/main/java/com/felkertech/cumulustv/player/MediaSourceFactory.java
+++ b/app/src/main/java/com/felkertech/cumulustv/player/MediaSourceFactory.java
@@ -81,7 +81,7 @@ public class MediaSourceFactory {
 
     public static HttpDataSource.Factory buildHttpDataSourceFactory(Context context,
              DefaultBandwidthMeter bandwidthMeter) {
-        String userAgent = Util.getUserAgent(context, "ExoPlayerDemo");
+        String userAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1";
         return new DefaultHttpDataSourceFactory(userAgent, bandwidthMeter);
     }
 


### PR DESCRIPTION
Previously, the user agent used was one of these:

ExoPlayerDemo/1.7.7 (Linux;Android 7.0) ExoPlayerLib/2.2.0
Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.35 Safari/537.36

The app claimed to be ExoPlayerDemo when trying to display a preview
when adding a channel while it claimed to be Chrome on Windows when
being used as a Live Channel. Neither choice was compatible with one of
the m3u8 streams that my mother likes to watch.

Without the option to set the User Agent per stream, it seems best to
use a single user agent that is broadly compatible, so lets go with the
iOS 11's useragent from the iPhone:

Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1

A better fix would be to make the user agent user configurable and
change the user agent to be customizable per stream, but this suffices
for my mother's purposes.

Also, the project's license is unclear. I had been very hesitant to
upstream a fix to a project without clarification on the license used by
the project. After some soul searching, I have decided to publish this
patch under the terms of either the Apache 2.0 or MIT licenses. If the
project lead wishes to fix the unclear licensing with a different OSS
license, I would likely be happy to follow suit. However, this fix
itself is so small that I doubt it qualifies for copyright protection,
so the license under which I choose to release it is likely a moot point
unless I start sending more patches.

Signed-off-by: Richard Yao <ryao@gentoo.org>